### PR TITLE
Integrate the debug text with the forge debug text rendering system

### DIFF
--- a/src/main/java/makamys/neodymium/Config.java
+++ b/src/main/java/makamys/neodymium/Config.java
@@ -58,8 +58,8 @@ public class Config {
     public static int maxMeshesPerFrame;
     @ConfigInt(cat="debug", def=Keyboard.KEY_F4, min=-1, max=Integer.MAX_VALUE, com="The LWJGL keycode of the key that has to be held down while pressing the debug keybinds. Setting this to 0 will make the keybinds usable without holding anything else down. Setting this to -1 will disable debug keybinds entirely.")
     public static int debugPrefix;
-    @ConfigInt(cat="debug", def=110, min=-1, max=Integer.MAX_VALUE, com="The Y position of the first line of the debug info in the F3 overlay. Set this to -1 to disable showing that info.")
-    public static int debugInfoStartY;
+    @ConfigBoolean(cat="debug", def=true, com="Set this to false to stop showing the debug info in the F3 overlay.")
+    public static boolean showDebugInfo;
     @ConfigBoolean(cat="debug", def=false)
     public static boolean wireframe;
     

--- a/src/main/java/makamys/neodymium/Neodymium.java
+++ b/src/main/java/makamys/neodymium/Neodymium.java
@@ -39,6 +39,8 @@ public class Neodymium
     public static final Logger LOGGER = LogManager.getLogger(MODID);
     
     private static final Config.ReloadInfo CONFIG_RELOAD_INFO = new Config.ReloadInfo();
+
+    private boolean renderDebugText = false;
     
     public static NeoRenderer renderer;
     
@@ -132,19 +134,15 @@ public class Neodymium
     }
     
     @SubscribeEvent
-    public void onRenderOverlay(RenderGameOverlayEvent event) {
-        FontRenderer fontRenderer = RenderManager.instance.getFontRenderer();
-        if(isActive() && event.type == ElementType.TEXT && fontRenderer != null && Minecraft.getMinecraft().gameSettings.showDebugInfo && (Config.debugInfoStartY != -1))
-        {
-            Minecraft mc = Minecraft.getMinecraft();
-            ScaledResolution scaledresolution = new ScaledResolution(mc, mc.displayWidth, mc.displayHeight);
-            int w = scaledresolution.getScaledWidth();
-            int h = scaledresolution.getScaledHeight();
-            
-            int yOffset = 0;
-            for(String s : renderer.getDebugText()) {
-                fontRenderer.drawStringWithShadow(s, w - fontRenderer.getStringWidth(s) - 10, Config.debugInfoStartY + yOffset, 0xFFFFFF);
-                yOffset += 10;
+    public void onRenderOverlay(RenderGameOverlayEvent.Pre event) {
+        if (Config.showDebugInfo && isActive()) {
+            if (event.type.equals(RenderGameOverlayEvent.ElementType.DEBUG)) {
+                renderDebugText = true;
+            } else if (renderDebugText && (event instanceof RenderGameOverlayEvent.Text) && event.type.equals(RenderGameOverlayEvent.ElementType.TEXT)) {
+                renderDebugText = false;
+                RenderGameOverlayEvent.Text text = (RenderGameOverlayEvent.Text) event;
+                text.right.add(null);
+                text.right.addAll(renderer.getDebugText());
             }
         }
     }


### PR DESCRIPTION
The current onRenderOverlay does not take into account how much text has been rendered on the debug overlay beforehand, and requires manual config changes when there's an overlap.

This PR changes the way that event callback works, and instead makes it add the debug info to the built-in debug text rendering system of forge, which makes it seamlessly append itself to any existing debug info that's already there.