### PR TITLE
Fixed RunClient in IntelliJ

### DIFF
--- a/buildscript/forge-1.7-mixin.gradle
+++ b/buildscript/forge-1.7-mixin.gradle
@@ -19,10 +19,11 @@ dependencies {
 			setTransitive false
 		}
 	} else {
-		compile('org.spongepowered:mixin:0.7.11-SNAPSHOT'){
+		implementation('org.spongepowered:mixin:0.7.11-SNAPSHOT'){
 			setTransitive false
 		}
 	}
+	annotationProcessor('org.spongepowered:mixin:0.7.11-SNAPSHOT')
 }
 
 ext.outRefMapFile = "${tasks.compileJava.temporaryDir}/${project.modid}.mixin.refmap.json"

--- a/buildscript/forge-1.7.gradle
+++ b/buildscript/forge-1.7.gradle
@@ -38,6 +38,11 @@ sourceCompatibility = 1.8
 targetCompatibility = 1.8
 
 repositories {
+	//Needed for forge userdev on gradle 6
+	maven {
+		name = "Overmind forge repo mirror"
+		url = "https://gregtech.overminddl1.com/"
+	}
 	maven {
 		name = "chickenbones"
 		url = "http://chickenbones.net/maven/"
@@ -46,9 +51,9 @@ repositories {
 
 configurations {
     embed
-    compile.extendsFrom(embed)
+    implementation.extendsFrom(embed)
 	shade
-    compile.extendsFrom(shade)
+	implementation.extendsFrom(shade)
 }
 
 if(project.enable_mixin.toBoolean()) {

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.4.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.9.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/project.gradle
+++ b/project.gradle
@@ -1,3 +1,5 @@
+import java.nio.file.Paths
+
 jar {
     manifest {
         attributes (
@@ -5,6 +7,7 @@ jar {
             'FMLAT': "neodymium_at.cfg"
         )
     }
+    exclude("META-INF/**.RSA")
 }
 
 repositories {
@@ -15,6 +18,20 @@ repositories {
 
 dependencies {
     compileOnly("com.falsepattern:triangulator-mc1.7.10:1.7.0:api")
+}
+
+runClient {
+    def arguments = []
+
+    arguments += [
+            "--mods=" + Paths.get("$projectDir").resolve(minecraft.runDir).normalize().relativize(Paths.get("$projectDir/build/libs/$archivesBaseName-${version}.jar"))
+    ]
+
+    arguments += [
+            "--tweakClass", "org.spongepowered.asm.launch.MixinTweaker"
+    ]
+
+    args(arguments)
 }
 
 apply from: "makalibs.gradle"


### PR DESCRIPTION
Even with genIntelliJRuns, the jvm was screaming about incorrect signatures, and mixins weren't loading, so it was effectively unusable in dev.

This fixes the runClient task so it should now just work out of the box on every IDE without extra setup.