### PR TITLE
Fix crash with FalseTweaks

### DIFF
--- a/src/main/java/makamys/neodymium/renderer/NeoRenderer.java
+++ b/src/main/java/makamys/neodymium/renderer/NeoRenderer.java
@@ -148,7 +148,7 @@ public class NeoRenderer {
 
                     initIndexBuffers();
                     
-                    if(!Constants.KEEP_RENDER_LIST_LOGIC) {
+                    if(!Constants.KEEP_RENDER_LIST_LOGIC && !Compat.isFalseTweaksModPresent()) {
                         updateRenderGlobalStats();
                     }
                 }


### PR DESCRIPTION
The FalseTweaks occlusion engine uses the renderer stats fields for internal state tracking